### PR TITLE
Merge Unlocked Threads branch

### DIFF
--- a/cuda_multiple_moments_threads.c
+++ b/cuda_multiple_moments_threads.c
@@ -110,7 +110,7 @@ __global__ void cudaKernel(int n, int grid_size, double* gpu_w, int* gpu_G, int*
 }
 
 // Cuda kernel function used to check for early exit if G == gTemp
-__global__ void exitKernel(int n, int* gpu_G, int* gpu_gTemp, int* gpu_exitFlag){
+__global__ void exitKernel(int n, int grid_size, int* gpu_G, int* gpu_gTemp, int* gpu_exitFlag){
 	
 	// Shared block exit flag
     __shared__ int blockFlag;
@@ -213,7 +213,7 @@ void ising( int *G, double *w, int k, int n){
 		gpu_gTemp = gpu_swapPtr;
 		
 		// Check for early exit
-		exitKernel<<<grid_size * grid_size, BLOCK_SIZE*BLOCK_SIZE>>>(n, gpu_G, gpu_gTemp, gpu_exitFlag);
+		exitKernel<<<grid_size * grid_size, BLOCK_SIZE*BLOCK_SIZE>>>(n, grid_size, gpu_G, gpu_gTemp, gpu_exitFlag);
 		cudaDeviceSynchronize();
 		cudaMemcpy(&exitFlag, gpu_exitFlag, sizeof(int), cudaMemcpyDeviceToHost);
 		if(exitFlag > 0)

--- a/cuda_multiple_moments_threads.c
+++ b/cuda_multiple_moments_threads.c
@@ -109,6 +109,49 @@ __global__ void cudaKernel(int n, int grid_size, double* gpu_w, int* gpu_G, int*
 	}
 }
 
+// Cuda kernel function used to check for early exit if G == gTemp
+__global__ void exitKernel(int n, int* gpu_G, int* gpu_gTemp, int* gpu_exitFlag){
+	
+	// Shared block exit flag
+    __shared__ int blockFlag;
+	
+	// Initialize blockFlag
+	if(threadIdx.x == 0)
+		blockFlag = 0;
+		
+	// Sync threads before continuing
+	__syncthreads();
+	
+	// Calculate thread id
+	int thread_id = blockIdx.x * BLOCK_SIZE * BLOCK_SIZE + threadIdx.x;
+	
+	// Check if thread id is within bounds and execute
+	if(thread_id < n*n){
+		
+		// Iterate through the moments assigned for each thread
+        for (int i = thread_id; (i < block_base + n * (BLOCK_SIZE - 1) + BLOCK_SIZE) && (i < n*n); ){
+		
+			// If two values are not the same, increment the flag
+			// This is not race-condition safe but we don't care since one write is guaranteed to finish
+			if(gpu_gTemp[i] == gpu_G[i]){
+				blockFlag += 1;
+				if(threadIdx.x != 0)
+					break;
+			}
+			
+			// Sync threads before writing to global
+			__syncthreads();
+			
+			// First thread of the block writes flag back to the global memory
+			if((threadIdx.x == 0) && (blockFlag > 0)){
+				*gpu_exitFlag+=1;
+				break;
+			}
+		}
+	}
+	
+}
+
 void printResult(int *G, int n){
     for(int i = 0; i < n; i++){
         for(int j = 0; j < n; j++){
@@ -141,6 +184,12 @@ void ising( int *G, double *w, int k, int n){
 	// Temporary pointer used for swapping gpu_G and gpu_gTemp
 	int *gpu_swapPtr;
 
+	// GPU early exit flag
+	int *gpu_exitFlag;
+	int exitFlag = 0;
+	cudaMalloc(&gpu_exitFlag, sizeof(int));
+	cudaMemcpy(gpu_exitFlag, &exitFlag, sizeof(int), cudaMemcpyHostToDevice);
+
 	// Define grid and block dimensions - avoid using dim objects for now
 	//dim3 dimGrid(GRID_SIZE, GRID_SIZE);
 	//dim3 dimBlock(BLOCK_SIZE, BLOCK_SIZE);
@@ -158,6 +207,13 @@ void ising( int *G, double *w, int k, int n){
 		gpu_swapPtr = gpu_G;
 		gpu_G = gpu_gTemp;
 		gpu_gTemp = gpu_swapPtr;
+		
+		// Check for early exit
+		exitKernel<<<grid_size * grid_size, BLOCK_SIZE*BLOCK_SIZE>>>(n, gpu_G, gpu_gTemp, gpu_exitFlag);
+		cudaDeviceSynchronize();
+		cudaMemcpy(&exitFlag, gpu_exitFlag, sizeof(int), cudaMemcpyDeviceToHost);
+		if(exitFlag > 0)
+			break;
 	}
 
 	// Copy final data to CPU memory

--- a/cuda_multiple_moments_threads.c
+++ b/cuda_multiple_moments_threads.c
@@ -3,7 +3,7 @@
 // Number of blocks on axis (GRID_SIZE^2 = number of blocks in grid)
 //#define GRID_SIZE 11  // Number is now dynamically decided based on n and BLOCK_SIZE
 
-// Threads per block (1024 resident blocks / 16 resident threads = 64 threads per block)
+// Threads per block (1024 resident threads / 16 resident blocks = 64 threads per block)
 #define BLOCK_THREADS 64
 
 #include <stdio.h>

--- a/cuda_multiple_moments_threads.c
+++ b/cuda_multiple_moments_threads.c
@@ -122,8 +122,12 @@ __global__ void exitKernel(int n, int* gpu_G, int* gpu_gTemp, int* gpu_exitFlag)
 	// Sync threads before continuing
 	__syncthreads();
 	
-	// Calculate thread id
-	int thread_id = blockIdx.x * BLOCK_SIZE * BLOCK_SIZE + threadIdx.x;
+    // Calculate thread_id based on the coordinates of the block
+    int blockX = blockIdx.x % grid_size;
+    int blockY = blockIdx.x / grid_size;
+    int block_base = blockX * BLOCK_SIZE + blockY * n * BLOCK_SIZE;
+    //FIX: If grid is not precise, this can get out of bounds
+    int thread_id = block_base + threadIdx.x % BLOCK_SIZE + n * (threadIdx.x / BLOCK_SIZE);
 	
 	// Check if thread id is within bounds and execute
 	if(thread_id < n*n){
@@ -239,7 +243,7 @@ int main(){
 
 	// Open binary file and write contents to an array
     FILE *fptr = fopen("conf-init.bin","rb");
-    int *G = (int*)scalloc(n*n, sizeof(int));
+    int *G = (int*)calloc(n*n, sizeof(int));
     if (fptr == NULL){
         printf("Error! opening file");
         exit(1);
@@ -252,7 +256,7 @@ int main(){
 
 	// Open results binary file and write contents to an array
     FILE *fptrR = fopen("conf-1.bin","rb");
-    int *R = (int*)scalloc(n*n, sizeof(int));
+    int *R = (int*)calloc(n*n, sizeof(int));
     if (fptrR == NULL){
         printf("Error! opening file");
         exit(1);

--- a/cuda_multiple_moments_threads.c
+++ b/cuda_multiple_moments_threads.c
@@ -3,8 +3,8 @@
 // Number of blocks on axis (GRID_SIZE^2 = number of blocks in grid)
 //#define GRID_SIZE 11  // Number is now dynamically decided based on n and BLOCK_SIZE
 
-// Threads per block
-#define BLOCK_THREADS 256
+// Threads per block (1024 resident blocks / 16 resident threads = 64 threads per block)
+#define BLOCK_THREADS 64
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/cuda_multiple_moments_threads.c
+++ b/cuda_multiple_moments_threads.c
@@ -56,7 +56,7 @@ __global__ void cudaKernel(int n, int grid_size, double* gpu_w, int* gpu_G, int*
 	if(thread_id < n*n){
 
         // Iterate through the moments assigned for each thread
-        for (int i = thread_id; (i < thread_id + n * BLOCK_SIZE) && (i < n*n); ){
+        for (int i = thread_id; (i <= block_base + n * (BLOCK_SIZE - 1) + BLOCK_SIZE) && (i < n*n); ){
             
             // Calculate moment's coordinates (i = y*n + x)
 	        x = i % n;

--- a/cuda_multiple_moments_threads.c
+++ b/cuda_multiple_moments_threads.c
@@ -144,7 +144,7 @@ __global__ void exitKernel(int n, int grid_size, int* gpu_G, int* gpu_gTemp, int
 		
 			// If two values are not the same, increment the flag
 			// This is not race-condition safe but we don't care since one write is guaranteed to finish
-			if(gpu_gTemp[i] == gpu_G[i]){
+			if(gpu_gTemp[i] != gpu_G[i]){
 				blockFlag += 1;
 				if(threadIdx.x != 0)
 					break;
@@ -228,7 +228,7 @@ void ising( int *G, double *w, int k, int n){
 		exitKernel<<<grid_size * grid_size, BLOCK_THREADS>>>(n, grid_size, gpu_G, gpu_gTemp, gpu_exitFlag);
 		cudaDeviceSynchronize();
 		cudaMemcpy(&exitFlag, gpu_exitFlag, sizeof(int), cudaMemcpyDeviceToHost);
-		if(exitFlag > 0)
+		if(exitFlag == 0)
 			break;
 	}
 

--- a/cuda_multiple_moments_threads.c
+++ b/cuda_multiple_moments_threads.c
@@ -50,13 +50,14 @@ __global__ void cudaKernel(int n, int grid_size, double* gpu_w, int* gpu_G, int*
     int blockX = blockIdx.x % grid_size;
     int blockY = blockIdx.x / grid_size;
     int block_base = blockX * BLOCK_SIZE + blockY * n * BLOCK_SIZE;
+    //FIX: If grid is not precise, this can get out of bounds
     int thread_id = block_base + threadIdx.x % BLOCK_SIZE + n * (threadIdx.x / BLOCK_SIZE);
 
 	// Check if thread id is within bounds and execute
 	if(thread_id < n*n){
 
         // Iterate through the moments assigned for each thread
-        for (int i = thread_id; (i <= block_base + n * (BLOCK_SIZE - 1) + BLOCK_SIZE) && (i < n*n); ){
+        for (int i = thread_id; (i < block_base + n * (BLOCK_SIZE - 1) + BLOCK_SIZE) && (i < n*n); ){
             
             // Calculate moment's coordinates (i = y*n + x)
 	        x = i % n;
@@ -148,7 +149,7 @@ void ising( int *G, double *w, int k, int n){
 	for(int i = 0; i < k; i++){
 
 		// Call cudaKernel for each iteration using pointers to cuda memory
-		cudaKernel<<<grid_size*grid_size, BLOCK_SIZE>>>(n, grid_size, gpu_w, gpu_G, gpu_gTemp);
+		cudaKernel<<<grid_size*grid_size, BLOCK_THREADS>>>(n, grid_size, gpu_w, gpu_G, gpu_gTemp);
 
 		// Synchronize threads before swapping pointers
 		cudaDeviceSynchronize();

--- a/cuda_multiple_moments_threads_shared_memory.c
+++ b/cuda_multiple_moments_threads_shared_memory.c
@@ -143,6 +143,65 @@ __global__ void cudaKernel(int n, int grid_size, double* gpu_w, int* gpu_G, int*
 	}
 }
 
+// Cuda kernel function used to check for early exit if G == gTemp
+__global__ void exitKernel(int n, int grid_size, int* gpu_G, int* gpu_gTemp, int* gpu_exitFlag){
+	
+	// Shared block exit flag
+    __shared__ int blockFlag;
+	
+	// Initialize blockFlag
+	if(threadIdx.x == 0)
+		blockFlag = 0;
+		
+	// Sync threads before continuing
+	__syncthreads();
+	
+    // Calculate thread_id based on the coordinates of the block
+    int blockX = blockIdx.x % grid_size;
+    int blockY = blockIdx.x / grid_size;
+    int block_base = blockX * BLOCK_SIZE + blockY * n * BLOCK_SIZE;
+    //FIX: If grid is not precise, this can get out of bounds
+    int thread_id = block_base + threadIdx.x % BLOCK_SIZE + n * (threadIdx.x / BLOCK_SIZE);
+	
+	// Moment coordinates
+	int x, y;
+	
+	// Check if thread id is within bounds and execute
+	if(thread_id < n*n){
+		
+		// Iterate through the moments assigned for each thread
+        for (int i = thread_id; (i < block_base + n * (BLOCK_SIZE - 1) + BLOCK_SIZE) && (i < n*n); ){
+			
+			// Calculate moment's coordinates (i = y*n + x)
+	        x = i % n;
+	        y = i / n;
+		
+			// If two values are not the same, increment the flag
+			// This is not race-condition safe but we don't care since one write is guaranteed to finish
+			if(gpu_gTemp[i] != gpu_G[i]){
+				blockFlag += 1;
+				if(threadIdx.x != 0)
+					break;
+			}
+			
+			// Sync threads before writing to global
+			__syncthreads();
+			
+			// First thread of the block writes flag back to the global memory
+			if((threadIdx.x == 0) && (blockFlag > 0)){
+				*gpu_exitFlag+=1;
+				break;
+			}
+			
+			// Calculate next i
+            // Calculate local i and increment by threads number, then calculate new global i
+            i = (y % BLOCK_SIZE) * BLOCK_SIZE + (x % BLOCK_SIZE) + BLOCK_THREADS;
+            i = block_base + i % BLOCK_SIZE + n * (i / BLOCK_SIZE);
+			
+		}
+	}
+}
+
 void printResult(int *G, int n){
     for(int i = 0; i < n; i++){
         for(int j = 0; j < n; j++){
@@ -174,6 +233,12 @@ void ising( int *G, double *w, int k, int n){
 
 	// Temporary pointer used for swapping gpu_G and gpu_gTemp
 	int *gpu_swapPtr;
+	
+	// GPU early exit flag
+	int *gpu_exitFlag;
+	int exitFlag = 0;
+	cudaMalloc(&gpu_exitFlag, sizeof(int));
+	cudaMemcpy(gpu_exitFlag, &exitFlag, sizeof(int), cudaMemcpyHostToDevice);
 
 	// Define grid and block dimensions - avoid using dim objects for now
 	//dim3 dimGrid(GRID_SIZE, GRID_SIZE);
@@ -192,6 +257,13 @@ void ising( int *G, double *w, int k, int n){
 		gpu_swapPtr = gpu_G;
 		gpu_G = gpu_gTemp;
 		gpu_gTemp = gpu_swapPtr;
+		
+		// Check for early exit
+		exitKernel<<<grid_size * grid_size, BLOCK_THREADS>>>(n, grid_size, gpu_G, gpu_gTemp, gpu_exitFlag);
+		cudaDeviceSynchronize();
+		cudaMemcpy(&exitFlag, gpu_exitFlag, sizeof(int), cudaMemcpyDeviceToHost);
+		if(exitFlag == 0)
+			break;
 	}
 
 	// Copy final data to CPU memory

--- a/cuda_multiple_moments_threads_shared_memory.c
+++ b/cuda_multiple_moments_threads_shared_memory.c
@@ -62,8 +62,9 @@ __global__ void cudaKernel(int n, int grid_size, double* gpu_w, int* gpu_G, int*
     // 1st caching method:     for(int sh_index = threadIdx.x; sh_index < CACHE_SIZE; sh_index += BLOCK_SIZE){
     // 2nd method: for(int sh_index = threadIdx.x  (CACHE_SIZE/BLOCK_THREADS + 1); (sh_index < (threadIdx.x + 1)  (CACHE_SIZE/BLOCK_THREADS + 1) + CACHE_SIZE/BLOCK_THREADS + 1) && (sh_index < CACHE_SIZE); sh_index ++){
     for(int sh_index = threadIdx.x * (CACHE_SIZE/BLOCK_THREADS + 1);
-    (sh_index < (threadIdx.x + 1) * (CACHE_SIZE/BLOCK_THREADS + 1) + CACHE_SIZE/BLOCK_THREADS + 1) && (sh_index < CACHE_SIZE);
-    sh_index ++){
+        (sh_index < (threadIdx.x + 1) * (CACHE_SIZE/BLOCK_THREADS + 1) + CACHE_SIZE/BLOCK_THREADS + 1) && (sh_index < CACHE_SIZE);
+        sh_index ++){
+
         // X and Y coordinates on the shared memory
         sh_x = sh_index % CACHE_LINE;
         sh_y = sh_index / CACHE_LINE;

--- a/cuda_multiple_moments_threads_shared_memory.c
+++ b/cuda_multiple_moments_threads_shared_memory.c
@@ -7,7 +7,7 @@
 #define CACHE_SIZE (CACHE_LINE * CACHE_LINE)
 
 // Threads per block (1024 resident threads / 16 resident blocks = 64 threads per block)
-#define BLOCK_THREADS 64
+#define BLOCK_THREADS 512
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -59,8 +59,11 @@ __global__ void cudaKernel(int n, int grid_size, double* gpu_w, int* gpu_G, int*
     int g_id, sh_x, sh_y, g_x, g_y;
 
     // Caching G to shared memory
-    for(int sh_index = threadIdx.x; sh_index < CACHE_SIZE; sh_index += BLOCK_SIZE){
-
+    // 1st caching method:     for(int sh_index = threadIdx.x; sh_index < CACHE_SIZE; sh_index += BLOCK_SIZE){
+    // 2nd method: for(int sh_index = threadIdx.x  (CACHE_SIZE/BLOCK_THREADS + 1); (sh_index < (threadIdx.x + 1)  (CACHE_SIZE/BLOCK_THREADS + 1) + CACHE_SIZE/BLOCK_THREADS + 1) && (sh_index < CACHE_SIZE); sh_index ++){
+    for(int sh_index = threadIdx.x * (CACHE_SIZE/BLOCK_THREADS + 1);
+    (sh_index < (threadIdx.x + 1) * (CACHE_SIZE/BLOCK_THREADS + 1) + CACHE_SIZE/BLOCK_THREADS + 1) && (sh_index < CACHE_SIZE);
+    sh_index ++){
         // X and Y coordinates on the shared memory
         sh_x = sh_index % CACHE_LINE;
         sh_y = sh_index / CACHE_LINE;

--- a/cuda_multiple_moments_threads_shared_memory.c
+++ b/cuda_multiple_moments_threads_shared_memory.c
@@ -62,7 +62,7 @@ __global__ void cudaKernel(int n, int grid_size, double* gpu_w, int* gpu_G, int*
     // 1st caching method:     for(int sh_index = threadIdx.x; sh_index < CACHE_SIZE; sh_index += BLOCK_SIZE){
     // 2nd method: for(int sh_index = threadIdx.x  (CACHE_SIZE/BLOCK_THREADS + 1); (sh_index < (threadIdx.x + 1)  (CACHE_SIZE/BLOCK_THREADS + 1) + CACHE_SIZE/BLOCK_THREADS + 1) && (sh_index < CACHE_SIZE); sh_index ++){
     for(int sh_index = threadIdx.x * (CACHE_SIZE/BLOCK_THREADS + 1);
-        (sh_index < (threadIdx.x + 1) * (CACHE_SIZE/BLOCK_THREADS + 1) + CACHE_SIZE/BLOCK_THREADS + 1) && (sh_index < CACHE_SIZE);
+        (sh_index < (threadIdx.x + 1) * (CACHE_SIZE/BLOCK_THREADS + 1)) && (sh_index < CACHE_SIZE);
         sh_index ++){
 
         // X and Y coordinates on the shared memory

--- a/cuda_multiple_moments_threads_shared_memory.c
+++ b/cuda_multiple_moments_threads_shared_memory.c
@@ -6,7 +6,7 @@
 #define CACHE_LINE (BLOCK_SIZE + 4)
 #define CACHE_SIZE (CACHE_LINE * CACHE_LINE)
 
-// Threads per block (1024 resident blocks / 16 resident threads = 64 threads per block)
+// Threads per block (1024 resident threads / 16 resident blocks = 64 threads per block)
 #define BLOCK_THREADS 64
 
 #include <stdio.h>
@@ -51,7 +51,7 @@ __global__ void cudaKernel(int n, int grid_size, double* gpu_w, int* gpu_G, int*
     // Calculate thread_id based on the coordinates of the block
     int blockX = blockIdx.x % grid_size;
     int blockY = blockIdx.x / grid_size;
-    int base_id = blockX * BLOCK_SIZE + blockY * n * BLOCK_SIZE;
+    int block_base = blockX * BLOCK_SIZE + blockY * n * BLOCK_SIZE;
     //FIX: If grid is not precise, this can get out of bounds
     int thread_id = block_base + threadIdx.x % BLOCK_SIZE + n * (threadIdx.x / BLOCK_SIZE);
 
@@ -179,7 +179,7 @@ void ising( int *G, double *w, int k, int n){
 	for(int i = 0; i < k; i++){
 
 		// Call cudaKernel for each iteration using pointers to cuda memory
-		cudaKernel<<<grid_size*grid_size, BLOCK_SIZE>>>(n, gpu_w, gpu_G, gpu_gTemp);
+		cudaKernel<<<grid_size*grid_size, BLOCK_THREADS>>>(n, grid_size, gpu_w, gpu_G, gpu_gTemp);
 
 		// Synchronize threads before swapping pointers
 		cudaDeviceSynchronize();

--- a/cuda_single_moment_threads.c
+++ b/cuda_single_moment_threads.c
@@ -37,12 +37,12 @@ __global__ void cudaKernel(int n, double* gpu_w, int* gpu_G, int* gpu_gTemp){
 		// Unrolled weights calculations for this moment
 		weightSum += gpu_w[0] * gpu_G[((-2 + y + n) % n) * n + (-2 + x + n) % n];
 		weightSum += gpu_w[1] * gpu_G[((-2 + y + n) % n) * n + (-1 + x + n) % n];
-		weightSum += gpu_w[2] * gpu_G[((-2 + y + n) % n) * n + (p + n) % n];
+		weightSum += gpu_w[2] * gpu_G[((-2 + y + n) % n) * n + (x + n) % n];
 		weightSum += gpu_w[3] * gpu_G[((-2 + y + n) % n) * n + (1 + x + n) % n];
 		weightSum += gpu_w[4] * gpu_G[((-2 + y + n) % n) * n + (2 + x + n) % n];
 		weightSum += gpu_w[5] * gpu_G[((-1 + y + n) % n) * n + (-2 + x + n) % n];
 		weightSum += gpu_w[6] * gpu_G[((-1 + y + n) % n) * n + (-1 + x + n) % n];
-		weightSum += gpu_w[7] * gpu_G[((-1 + y + n) % n) * n + (p + n) % n];
+		weightSum += gpu_w[7] * gpu_G[((-1 + y + n) % n) * n + (x + n) % n];
 		weightSum += gpu_w[8] * gpu_G[((-1 + y + n) % n) * n + (1 + x + n) % n];
 		weightSum += gpu_w[9] * gpu_G[((-1 + y + n) % n) * n + (2 + x + n) % n];
 		weightSum += gpu_w[10] * gpu_G[((y + n) % n) * n + (-2 + x + n) % n];
@@ -51,12 +51,12 @@ __global__ void cudaKernel(int n, double* gpu_w, int* gpu_G, int* gpu_gTemp){
 		weightSum += gpu_w[14] * gpu_G[((y + n) % n) * n + (2 + x + n) % n];
 		weightSum += gpu_w[15] * gpu_G[((1 + y + n) % n) * n + (-2 + x + n) % n];
 		weightSum += gpu_w[16] * gpu_G[((1 + y + n) % n) * n + (-1 + x + n) % n];
-		weightSum += gpu_w[17] * gpu_G[((1 + y + n) % n) * n + (p + n) % n];
+		weightSum += gpu_w[17] * gpu_G[((1 + y + n) % n) * n + (x + n) % n];
 		weightSum += gpu_w[18] * gpu_G[((1 + y + n) % n) * n + (1 + x + n) % n];
 		weightSum += gpu_w[19] * gpu_G[((1 + y + n) % n) * n + (2 + x + n) % n];
 		weightSum += gpu_w[20] * gpu_G[((2 + y + n) % n) * n + (-2 + x + n) % n];
 		weightSum += gpu_w[21] * gpu_G[((2 + y + n) % n) * n + (-1 + x + n) % n];
-		weightSum += gpu_w[22] * gpu_G[((2 + y + n) % n) * n + (p + n) % n];
+		weightSum += gpu_w[22] * gpu_G[((2 + y + n) % n) * n + (x + n) % n];
 		weightSum += gpu_w[23] * gpu_G[((2 + y + n) % n) * n + (1 + x + n) % n];
 		weightSum += gpu_w[24] * gpu_G[((2 + y + n) % n) * n + (2 + x + n) % n];
 

--- a/cuda_single_moment_threads.c
+++ b/cuda_single_moment_threads.c
@@ -75,7 +75,14 @@ __global__ void cudaKernel(int n, double* gpu_w, int* gpu_G, int* gpu_gTemp){
 __global__ void exitKernel(int n, int* gpu_G, int* gpu_gTemp, int* gpu_exitFlag){
 	
 	// Shared block exit flag
-    __shared__ int blockFlag = 0;
+    __shared__ int blockFlag;
+	
+	// Initialize blockFlag
+	if(threadIdx.x == 0)
+		blockFlag = 0;
+		
+	// Sync threads before continuing
+	__syncthreads();
 	
 	// Calculate thread id
 	int thread_id = blockIdx.x * BLOCK_SIZE * BLOCK_SIZE + threadIdx.x;
@@ -89,7 +96,7 @@ __global__ void exitKernel(int n, int* gpu_G, int* gpu_gTemp, int* gpu_exitFlag)
 	__syncthreads();
 	
 	// First thread of the block writes flag back to the global memory
-	if((thread_id == blockIdx.x * BLOCK_SIZE * BLOCK_SIZE) && (blockFlag > 0))
+	if((threadIdx.x == 0) && (blockFlag > 0))
 		atomicAdd(gpu_exitFlag, blockFlag);
 	
 }

--- a/cuda_single_moment_threads.c
+++ b/cuda_single_moment_threads.c
@@ -71,6 +71,30 @@ __global__ void cudaKernel(int n, double* gpu_w, int* gpu_G, int* gpu_gTemp){
 	}
 }
 
+// Cuda kernel function used to check for early exit if G == gTemp
+__global__ void exitKernel(int n, int* gpu_G, int* gpu_gTemp, int* gpu_exitFlag){
+	
+	// Shared block exit flag
+    __shared__ int blockFlag = 0;
+	
+	// Calculate thread id
+	int thread_id = blockIdx.x * BLOCK_SIZE * BLOCK_SIZE + threadIdx.x;
+	
+	// If two values are not the same, increment the flag
+	// This is not race-condition safe but we don't care since one write is guaranteed to finish
+	if(gpu_gTemp[thread_id] == gpu_G[thread_id])
+		atomicAdd(&blockFlag, 1);
+	
+	// Sync threads before writing to global
+	__syncthreads();
+	
+	// First thread of the block writes flag back to the global memory
+	if((thread_id == blockIdx.x * BLOCK_SIZE * BLOCK_SIZE) && (blockFlag > 0))
+		atomicAdd(gpu_exitFlag, blockFlag);
+	
+}
+
+
 void printResult(int *G, int n){
     for(int i = 0; i < n; i++){
         for(int j = 0; j < n; j++){
@@ -103,6 +127,12 @@ void ising( int *G, double *w, int k, int n){
 
 	// Temporary pointer used for swapping gpu_G and gpu_gTemp
 	int *gpu_swapPtr;
+	
+	// GPU early exit flag
+	int *gpu_exitFlag;
+	int exitFlag = 0;
+	cudaMalloc(&gpu_exitFlag, sizeof(int));
+	cudaMemcpy(gpu_exitFlag, &exitFlag, sizeof(int), cudaMemcpyHostToDevice);
 
 	// Define grid and block dimensions - disabled for now
 	//dim3 dimGrid(GRID_SIZE, GRID_SIZE);
@@ -121,6 +151,14 @@ void ising( int *G, double *w, int k, int n){
 		gpu_swapPtr = gpu_G;
 		gpu_G = gpu_gTemp;
 		gpu_gTemp = gpu_swapPtr;
+		
+		// Check for early exit
+		exitKernel<<<grid_size * grid_size, BLOCK_SIZE*BLOCK_SIZE>>>(n, gpu_G, gpu_gTemp, gpu_exitFlag);
+		cudaDeviceSynchronize();
+		cudaMemcpy(&exitFlag, gpu_exitFlag, sizeof(int), cudaMemcpyDeviceToHost);
+		if(exitFlag > 0)
+			break;
+		
 	}
 
 	// Copy final data to CPU memory

--- a/cuda_single_moment_threads.c
+++ b/cuda_single_moment_threads.c
@@ -91,7 +91,7 @@ __global__ void exitKernel(int n, int* gpu_G, int* gpu_gTemp, int* gpu_exitFlag)
 	if(thread_id < n*n){
 		// If two values are not the same, increment the flag
 		// This is not race-condition safe but we don't care since one write is guaranteed to finish
-		if(gpu_gTemp[thread_id] == gpu_G[thread_id])
+		if(gpu_gTemp[thread_id] != gpu_G[thread_id])
 			blockFlag += 1;
 		
 		// Sync threads before writing to global
@@ -166,7 +166,7 @@ void ising( int *G, double *w, int k, int n){
 		exitKernel<<<grid_size * grid_size, BLOCK_SIZE*BLOCK_SIZE>>>(n, gpu_G, gpu_gTemp, gpu_exitFlag);
 		cudaDeviceSynchronize();
 		cudaMemcpy(&exitFlag, gpu_exitFlag, sizeof(int), cudaMemcpyDeviceToHost);
-		if(exitFlag > 0)
+		if(exitFlag == 0)
 			break;
 		
 	}

--- a/cuda_single_moment_threads.c
+++ b/cuda_single_moment_threads.c
@@ -63,11 +63,11 @@ __global__ void cudaKernel(int n, double* gpu_w, int* gpu_G, int* gpu_gTemp){
 		// Decide on what future moment should be based on temp:
 		// If positive, set to 1. If negative, to -1. If 0, leave untouched
 		if(weightSum > 0.0001)
-			gpu_gTemp[i] = 1;
+			gpu_gTemp[thread_id] = 1;
 		else if(weightSum < -0.0001)
-			gpu_gTemp[i] = -1;
+			gpu_gTemp[thread_id] = -1;
 		else
-			gpu_gTemp[i] = gpu_G[i];
+			gpu_gTemp[thread_id] = gpu_G[thread_id];
 	}
 }
 

--- a/sequential_optimized.c
+++ b/sequential_optimized.c
@@ -89,6 +89,19 @@ void ising( int *G, double *w, int k, int n){
 		swapPtr = G;
 		G = gTemp;
 		gTemp = swapPtr;
+		
+		// Check if gTemp == G - if so, no point in performing more iterations
+		// Use weightSum as a boolean variable to avoid declaring another variable
+		weightSum = 0;
+		for(int k = 0; k < n*n; k++){
+			if(gTemp[k] != G[k]){
+				weightSum = 1;
+				break;
+			}
+		}
+		if(weightSum != 1)
+			break;
+		
 	}
 
 	/* If final k is odd, the current data is in the original gTemp's memory space where G (pointer) 


### PR DESCRIPTION
The unlocked threads branch unlocks the number of threads from the block size. So the number of threads per block can be independent of the block size (as is thread number must be >= block_size^2 which is the size of the block in moments).

This is done by assigning a thread_id based on local block coordinates and incrementing by the number of threads within the block and finally converting the local block coordinates to global G matrix coordinates. 